### PR TITLE
remove references to old repo vgramer/opa-idea-plugin

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,12 @@
 <!--  Thanks for sending a pull request!  Before submitting your PR, some kind reminder
 
-* If this is your first PR, please read our contributor guidelines: https://github.com/vgramer/opa-idea-plugin/blob/master/CONTRIBUTING.md
+* If this is your first PR, please read our contributor guidelines: https://github.com/open-policy-agent/opa-idea-plugin/blob/master/CONTRIBUTING.md
 
 * Code should be accompanied by tests whenever it's possible.
 
 * New feature must be documented
 
-For more information about the project architecture please take a look at https://github.com/vgramer/opa-idea-plugin/tree/master/docs/devel
+For more information about the project architecture please take a look at https://github.com/open-policy-agent/opa-idea-plugin/tree/master/docs/devel
 
 -->
 

--- a/docs/devel/setup_development_env.md
+++ b/docs/devel/setup_development_env.md
@@ -28,7 +28,7 @@ Just clone the project and execute the tests to ensure everything is ok.
 
 ```bash
 # clone the project 
-$ git clone git@github.com:vgramer/opa-idea-plugin.git
+$ git clone git@github.com:open-policy-agent/opa-idea-plugin.git
 $ cd opa-idea-plugin
 
 # run tests

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -6,8 +6,8 @@
 <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude" allow-bundled-update="true">
     <id>org.openpolicyagent.opa-idea-plugin</id>
     <name>Open Policy Agent</name>
-    <vendor email="open-policy-agent-intellij-private@googlegroups.com" url="https://github.com/vgramer/opa-idea-plugin">
-        https://github.com/vgramer/opa-idea-plugin
+    <vendor email="open-policy-agent-intellij-private@googlegroups.com" url="https://github.com/open-policy-agent/opa-idea-plugin">
+        https://github.com/open-policy-agent/opa-idea-plugin
     </vendor>
 
     <description><![CDATA[


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting your PR, some kind reminder

* If this is your first PR, please read our contributor guidelines: https://github.com/vgramer/opa-idea-plugin/blob/master/CONTRIBUTING.md

* Code should be accompanied by tests whenever it's possible.

* New feature must be documented

For more information about the project architecture please take a look at https://github.com/vgramer/opa-idea-plugin/tree/master/docs/devel

-->

# Description
Remove references to old repo `vgramer/opa-idea-plugin`. The repository has been transferred to `open-policy-agent` organization
 
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`

If you just want to link an issue but not automatically close it, use `Ref #<issue number>` instead of  `Fixes`
-->
Fixes #

# Special notes for your reviewer

On [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/14865-open-policy-agent), I have updated the link to the bug tracker, source code, and documentation. The vendor URL will be updated with the next release  of the plugin (This information comes from the plugin archive) 