### PR TITLE
fix grammar: allow empty query in else clause

### DIFF
--- a/src/main/grammar/Rego.bnf
+++ b/src/main/grammar/Rego.bnf
@@ -66,16 +66,18 @@
 module              ::= package (import|  rule)*
 package             ::= "package" ref
 import              ::= "import" ref ( "as" var )?
-rule                ::=  "default"?  rule-head  rule-body*
+rule                ::= "default"?  rule-head  rule-body*
 rule-head           ::= var ( "(" rule-args? ")" )? ("[" term "]" )? ( ( ":=" | "=" ) expr2 )?
 rule-args           ::= term ( "," term )*
-rule-body           ::= ( else ( "=" expr2 )? )? "{" query "}"
-query               ::=( literal |';' )+
+rule-body           ::= else-expr  | query-block
+else-expr           ::= else "=" expr2  query-block? | else "="? query-block
+query-block         ::= "{" query "}"
+query               ::= ( literal |';' )+
 literal             ::= ( some-decl | expr | "not" expr )  with-modifier*
 with-modifier       ::= "with" term "as" term
 some-decl           ::= "some" var ( "," var )*
-expr                ::=  expr2  ((':=' | '=') expr2)?
-expr2               ::=  expr-infix | (expr-call ref-arg*)  | term
+expr                ::= expr2  ((':=' | '=') expr2)?
+expr2               ::= expr-infix | (expr-call ref-arg*)  | term
 term-or-infix-op    ::= term (infix-operator term)?
 expr-call           ::= var ref-arg-dot* "(" ( term-or-infix-op ( "," term-or-infix-op )* )? ")"
 expr-infix          ::= term infix-operator term (infix-operator term)*

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/lang/RegoParsingTestCaseBase.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/lang/RegoParsingTestCaseBase.kt
@@ -17,7 +17,7 @@ import org.openpolicyagent.ideaplugin.lang.parser.RegoParserDefinition
 import org.openpolicyagent.ideaplugin.opa.tool.OpaBaseTool.Companion.opaBinary
 
 
-abstract class RegoParsingTestCaseBase() : ParsingTestCase(
+abstract class RegoParsingTestCaseBase : ParsingTestCase(
     "org/openpolicyagent/ideaplugin/lang/parser/fixtures",
     "rego",
     true,

--- a/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/else_keyword.rego
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/else_keyword.rego
@@ -43,3 +43,42 @@ check_object_comprehension_for_else(x) = x {
 } else = {y : "true" | some y;  a[y] } {
     true
 }
+
+check_only_querry_for_else = true {
+ false
+} else {
+    true
+}
+
+check_only_equal_querry_for_else = true {
+ false
+} else = {
+    true
+}
+
+# issue 84
+check_empty_query_else = true {
+    input.x < input.y
+} else = false
+
+
+check_empty_query_else_with_number = 3 {
+    input.x < input.y
+} else = 2
+
+check_empty_query_else_with_string = "ok" {
+    input.x < input.y
+} else = "ko"
+
+check_empty_query_else_with_array= ["ok", "yes"] {
+    input.x < input.y
+} else = ["ko", "no"]
+
+check_empty_query_else_with_set= { 0 ,2 ,3 } {
+    input.x < input.y
+} else = { 4, 5, 6 }
+
+
+check_empty_query_else_with_infix_op= 0 {
+    input.x < input.y
+} else = abs(input.x) + 10 - input.y


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting your PR, some kind reminder

* If this is your first PR, please read our contributor guidelines: https://github.com/open-policy-agent/opa-idea-plugin/blob/master/CONTRIBUTING.md

* Code should be accompanied by tests whenever it's possible.

* New feature must be documented

For more information about the project architecture please take a look at https://github.com/open-policy-agent/opa-idea-plugin/tree/master/docs/devel

-->

# Description

Fix 2 problems with else statement:

1.  previously: `else` must be followed by "{" query "}". Consequently, this valid code was reported as an error
```
package com.foo

foo = true {
    input.x < input.y
} else = false
```

2. previously `else =` must be followed by `expr2`.  Consequently, this valid code was reported as an error
```
check_only_equal_querry_for_else = true {
 false
} else = {
    true
}
```

 
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`

If you just want to link an issue but not automatically close it, use `Ref #<issue number>` instead of  `Fixes`
-->
Fixes #84 

# Special notes for your reviewer

<!-- if your notes are small enough, you can directly comment your PR in the review section --> 