### PR TITLE
Fix grammar: allow factor expression

### DIFF
--- a/src/main/grammar/Rego.bnf
+++ b/src/main/grammar/Rego.bnf
@@ -78,9 +78,9 @@ with-modifier       ::= "with" term "as" term
 some-decl           ::= "some" var ( "," var )*
 expr                ::= expr2  ((':=' | '=') expr2)?
 expr2               ::= expr-infix | (expr-call ref-arg*)  | term
-term-or-infix-op    ::= term (infix-operator term)?
-expr-call           ::= var ref-arg-dot* "(" ( term-or-infix-op ( "," term-or-infix-op )* )? ")"
-expr-infix          ::= term infix-operator term (infix-operator term)*
+expr-call           ::= var ref-arg-dot* "(" ( expr2 ( "," expr2 )* )? ")"
+expr-infix          ::= factor-expr  (infix-operator factor-expr)*
+factor-expr         ::= ("(" expr-infix ")") | term
 term                ::= ref | var | scalar | array | object | set | array-compr | object-compr | set-compr
 array-compr         ::= "[" term "|" query "]"
 set-compr           ::= "{" term "|" query "}"

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/lang/RegoParsingTestCase.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/lang/RegoParsingTestCase.kt
@@ -54,4 +54,5 @@ class RegoParsingTestCase: RegoParsingTestCaseBase() {
     fun `test variables`() = doTestNoError()
 
     fun `test ref arg back`() = doTestNoError()
+    fun `test factor expr`() = doTestNoError()
 }

--- a/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/factor_expr.rego
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/factor_expr.rego
@@ -1,0 +1,24 @@
+package main
+
+location := []
+
+
+a1= (1)
+a2:= (1) + (2)
+a3:= (1 - 3)  * 2
+a4:= (1 - 3)  * (2 +5)
+a5:= ((1 - 3)  * 2) / count([1, 2])
+
+reverse(l) = [l[j] | _ = l[i]; j := (count(l) - 1) - i]
+
+c1(l, x) = location[minus(count(location),1) + 2] {
+	true
+}
+
+
+rule1 {
+    (1 +2 ) * 0 = 0
+
+    c:= minus(count(location),(1 /2) * 2)
+    d:= abs((1 - 2) % 4)
+}


### PR DESCRIPTION
# Description
This PR adds the possibility to use factor expression (ie parenthesis )

The parsing of these expressions was failing:

```
a4:= (1 - 3)  * (2 +5)

reverse(l) = [l[j] | _ = l[i]; j := (count(l) - 1) - i]

```


# Special notes for your reviewer

