### PR TITLE
add option to configure env vars in eval/test config

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ propertiesPluginEnvironmentNameProperty=platformVersion
 
 # Supported platforms: 203, 211
 platformVersion=211
-majorVersion=0.6
+majorVersion=0.7
 patchVersion=0
 
 

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/OpaEvalRunConfiguration.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/OpaEvalRunConfiguration.kt
@@ -5,6 +5,7 @@
 package org.openpolicyagent.ideaplugin.ide.runconfig
 
 import com.intellij.execution.Executor
+import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.execution.configurations.*
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.options.SettingsEditor
@@ -34,7 +35,7 @@ class OpaEvalRunConfiguration(
 ) : LocatableConfigurationBase<OpaEvalRunProfileState>(project, factory, name) {
 
     /**
-     * the querry to evaluate
+     * the query to evaluate
      */
     var query: String? = null
 
@@ -53,6 +54,7 @@ class OpaEvalRunConfiguration(
      * others arguments to pass to opa eval command (eg -f pretty)
      */
     var additionalArgs: String? = null
+    var env: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
 
 
     override fun suggestedName(): String? {
@@ -110,7 +112,8 @@ class OpaEvalRunConfiguration(
         query = element.readString("query")
         input = element.readPath("input")
         bundleDir = element.readPath("bundledir")
-        additionalArgs = element.readString("addtionalargs")
+        additionalArgs = element.readString("additionalargs")
+        env = EnvironmentVariablesData.readExternal(element)
     }
 
     /**
@@ -123,7 +126,8 @@ class OpaEvalRunConfiguration(
         element.writeString("query", query)
         element.writePath("input", input)
         element.writePath("bundledir", bundleDir)
-        element.writeString("addtionalargs", additionalArgs)
+        element.writeString("additionalargs", additionalArgs)
+        env.writeExternal(element)
 
     }
 }

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/OpaEvalRunProfileState.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/OpaEvalRunProfileState.kt
@@ -35,6 +35,7 @@ class OpaEvalRunProfileState(
         args.add(runConfiguration.query)
 
         val cmd = GeneralCommandLine(OpaBaseTool.opaBinary)
+            .withEnvironment(runConfiguration.env.envs)
             .withParameters("eval")
             .withParameters(args)
             .withCharset(StandardCharsets.UTF_8)

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/OpaTestRunConfiguration.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/OpaTestRunConfiguration.kt
@@ -5,6 +5,7 @@
 package org.openpolicyagent.ideaplugin.ide.runconfig.test
 
 import com.intellij.execution.Executor
+import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.execution.configurations.*
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.options.SettingsEditor
@@ -42,6 +43,7 @@ class OpaTestRunConfiguration(
      * others arguments to pass to opa eval command (eg -f pretty)
      */
     var additionalArgs: String? = null
+    var env: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
 
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration?> = OpaTestRunCommandEditor(project)
@@ -61,7 +63,7 @@ class OpaTestRunConfiguration(
             throw RuntimeConfigurationError("Only format option (-f or --format) = pretty is handle by plugin")
         }
 
-        if (bundleDir == null || bundleDir!!.isFile()){
+        if (bundleDir == null || bundleDir!!.isFile()) {
             throw RuntimeConfigurationError("Bundle directory must be a directory")
         }
     }
@@ -92,7 +94,9 @@ class OpaTestRunConfiguration(
         super.readExternal(element)
 
         bundleDir = element.readPath("bundledir")
-        additionalArgs = element.readString("addtionalargs")
+        additionalArgs = element.readString("additionalargs")
+        env = EnvironmentVariablesData.readExternal(element)
+
     }
 
     /**
@@ -103,7 +107,8 @@ class OpaTestRunConfiguration(
         super.writeExternal(element)
 
         element.writePath("bundledir", bundleDir)
-        element.writeString("addtionalargs", additionalArgs)
+        element.writeString("additionalargs", additionalArgs)
+        env.writeExternal(element)
     }
 }
 

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/OpaTestRunProfileState.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/OpaTestRunProfileState.kt
@@ -52,6 +52,7 @@ class OpaTestRunProfileState(
         }
 
         val cmd = GeneralCommandLine(OpaBaseTool.opaBinary)
+            .withEnvironment(runConfiguration.env.envs)
             .withParameters("test")
             .withParameters(args)
             .withCharset(StandardCharsets.UTF_8)

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/ui/OpaTestRunCommandEditor.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/ui/OpaTestRunCommandEditor.kt
@@ -10,6 +10,8 @@
 
 package org.openpolicyagent.ideaplugin.ide.runconfig.test.ui
 
+import com.intellij.execution.configuration.EnvironmentVariablesComponent
+import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
@@ -37,6 +39,7 @@ class OpaTestRunCommandEditor(private val project: Project) : SettingsEditor<Opa
         )
     }
     private var additionalArgs = RawCommandLineEditor()
+    private val environmentVariables = EnvironmentVariablesComponent()
 
     override fun createEditor() = panel {
         row("Bundle:") {
@@ -46,6 +49,10 @@ class OpaTestRunCommandEditor(private val project: Project) : SettingsEditor<Opa
         row("Additional Args:") {
             additionalArgs.apply { preferredSize = Dimension(1000, height) }()
         }
+
+        row(environmentVariables.label) {
+            environmentVariables()
+        }
     }
 
     /**
@@ -54,6 +61,7 @@ class OpaTestRunCommandEditor(private val project: Project) : SettingsEditor<Opa
     override fun applyEditorTo(s: OpaTestRunConfiguration) {
         s.bundleDir = bundle.text.toPath()
         s.additionalArgs = additionalArgs.text
+        s.env = environmentVariables.envData
     }
 
     /**
@@ -62,6 +70,7 @@ class OpaTestRunCommandEditor(private val project: Project) : SettingsEditor<Opa
     override fun resetEditorFrom(s: OpaTestRunConfiguration) {
         bundle.text = s.bundleDir?.toString() ?: ""
         additionalArgs.text = s.additionalArgs ?: ""
+        environmentVariables.envData = s.env
     }
 
     private fun String.toPath(): Path? {

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/ui/OpaEvalRunCommandEditor.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/ui/OpaEvalRunCommandEditor.kt
@@ -5,6 +5,7 @@
 
 package org.openpolicyagent.ideaplugin.ide.runconfig.ui
 
+import com.intellij.execution.configuration.EnvironmentVariablesComponent
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.fileChooser.FileTypeDescriptor
 import com.intellij.openapi.options.SettingsEditor
@@ -44,6 +45,7 @@ class OpaEvalRunCommandEditor(private val project: Project) : SettingsEditor<Opa
         )
     }
     private var additionalArgs = RawCommandLineEditor()
+    private val environmentVariables = EnvironmentVariablesComponent()
 
     override fun createEditor() = panel {
         row("Query:") {
@@ -61,6 +63,10 @@ class OpaEvalRunCommandEditor(private val project: Project) : SettingsEditor<Opa
         row("Additional Args:") {
             additionalArgs.apply { preferredSize = Dimension(1000, height) }()
         }
+
+        row(environmentVariables.label) {
+            environmentVariables()
+        }
     }
 
     /**
@@ -71,6 +77,7 @@ class OpaEvalRunCommandEditor(private val project: Project) : SettingsEditor<Opa
         s.input = input.text.toPath()
         s.bundleDir = bundle.text.toPath()
         s.additionalArgs = additionalArgs.text
+        s.env = environmentVariables.envData
     }
 
     /**
@@ -81,6 +88,7 @@ class OpaEvalRunCommandEditor(private val project: Project) : SettingsEditor<Opa
         input.text = s.input?.toString() ?: ""
         bundle.text = s.bundleDir?.toString() ?: ""
         additionalArgs.text = s.additionalArgs ?: ""
+        environmentVariables.envData = s.env
     }
 
     private fun String.toPath(): Path? {

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/OpaEvalRunConfigurationTest.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/OpaEvalRunConfigurationTest.kt
@@ -5,6 +5,7 @@
 
 package org.openpolicyagent.ideaplugin.ide.runconfig
 
+import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.execution.configurations.RuntimeConfigurationError
 import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.runners.ExecutionEnvironment
@@ -92,13 +93,13 @@ class OpaEvalRunConfigurationTest : RunConfigurationTestBase() {
         runConfig.checkConfiguration()
     }
 
-    fun `test configuration must be check be call getState`(){
+    fun `test configuration must be check be call getState`() {
         val runConfig = buildProjectAndGetRunConfig("", validInput(), validBundleDir(), validAdditionalArgs())
 
         try {
             runConfig.getState(DefaultRunExecutor(), ExecutionEnvironment())
             failBecauseExceptionWasNotThrown<RuntimeConfigurationError>(RuntimeConfigurationError::class.java)
-        }catch (e: RuntimeConfigurationError){
+        } catch (e: RuntimeConfigurationError) {
             assertThat(e).hasMessage("Query can not be empty")
         }
     }
@@ -111,7 +112,8 @@ class OpaEvalRunConfigurationTest : RunConfigurationTestBase() {
         data.writeString("query", validQuery())
         data.writePath("input", validInput())
         data.writePath("bundledir", validBundleDir())
-        data.writeString("addtionalargs", validAdditionalArgs())
+        data.writeString("additionalargs", validAdditionalArgs())
+        runConfig.env.writeExternal(data)
 
         runConfig.readExternal(data)
 
@@ -119,6 +121,7 @@ class OpaEvalRunConfigurationTest : RunConfigurationTestBase() {
         assertThat(runConfig.input).isEqualTo(validInput())
         assertThat(runConfig.bundleDir).isEqualTo(validBundleDir())
         assertThat(runConfig.additionalArgs).isEqualTo(validAdditionalArgs())
+        assertThat(runConfig.env).isEqualTo(validEnvs())
     }
 
     fun `test write external`() {
@@ -128,6 +131,7 @@ class OpaEvalRunConfigurationTest : RunConfigurationTestBase() {
         runConfig.bundleDir = validBundleDir()
         runConfig.input = validInput()
         runConfig.additionalArgs = validAdditionalArgs()
+        runConfig.env = validEnvs()
 
         val elem = Element("root")
         runConfig.writeExternal(elem)
@@ -137,7 +141,8 @@ class OpaEvalRunConfigurationTest : RunConfigurationTestBase() {
         expected.writeString("query", runConfig.query)
         expected.writePath("input", runConfig.input)
         expected.writePath("bundledir", runConfig.bundleDir)
-        expected.writeString("addtionalargs", runConfig.additionalArgs)
+        expected.writeString("additionalargs", runConfig.additionalArgs)
+        runConfig.env.writeExternal(expected)
 
         assertThat(elem.toXmlString()).isEqualTo(expected.toXmlString())
 
@@ -147,6 +152,7 @@ class OpaEvalRunConfigurationTest : RunConfigurationTestBase() {
     private fun validInput(): Path = Paths.get("${myFixture.tempDirPath}/${bundleDirName}/${inputFileName}")
     private fun validBundleDir(): Path = Paths.get("${myFixture.tempDirPath}/${bundleDirName}")
     private fun validAdditionalArgs() = "-f pretty --fail-defined"
+    private fun validEnvs() = EnvironmentVariablesData.DEFAULT
 
     private fun doCheckConfigError(
         query: String?,
@@ -170,7 +176,8 @@ class OpaEvalRunConfigurationTest : RunConfigurationTestBase() {
         query: String?,
         input: Path?,
         bundleDir: Path?,
-        additionalsArgs: String?
+        additionalArgs: String?,
+        env: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
     ): OpaEvalRunConfiguration {
         buildProject {
             dir(bundleDirName) {
@@ -188,7 +195,8 @@ class OpaEvalRunConfigurationTest : RunConfigurationTestBase() {
         runConfig.query = query
         runConfig.input = input
         runConfig.bundleDir = bundleDir
-        runConfig.additionalArgs = additionalsArgs
+        runConfig.additionalArgs = additionalArgs
+        runConfig.env = env
         return runConfig
     }
 

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/RunConfigurationTestBase.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/RunConfigurationTestBase.kt
@@ -6,6 +6,7 @@
 package org.openpolicyagent.ideaplugin.ide.runconfig
 
 import com.intellij.execution.ExecutionResult
+import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.process.ProcessAdapter
@@ -25,7 +26,8 @@ abstract class RunConfigurationTestBase : OpaWithRealProjectTestBase() {
         query: String? = null,
         input: Path? = null,
         bundleDir: Path? = null,
-        additionalArgs: String? = null
+        additionalArgs: String? = null,
+        env: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
     ): OpaEvalRunConfiguration {
         val runConfig = OpaConfigurationFactory(OpaEvalRunConfigurationType())
             .createTemplateConfiguration(myFixture.project) as OpaEvalRunConfiguration
@@ -34,6 +36,7 @@ abstract class RunConfigurationTestBase : OpaWithRealProjectTestBase() {
         runConfig.bundleDir = bundleDir
         runConfig.input = input
         runConfig.additionalArgs = additionalArgs
+        runConfig.env = env
 
 
         return runConfig

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/OpaTestRunConfigurationBase.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/OpaTestRunConfigurationBase.kt
@@ -5,6 +5,7 @@
 
 package org.openpolicyagent.ideaplugin.ide.runconfig.test
 
+import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.execution.filters.HyperlinkInfo
 import com.intellij.execution.testframework.Printable
@@ -24,12 +25,17 @@ import java.nio.file.Paths
 
 abstract class OpaTestRunConfigurationBase : RunConfigurationTestBase() {
 
-    fun createTestConfig(bundleDir: Path? = null, additionalArgs: String? = null): OpaTestRunConfiguration {
+    fun createTestConfig(
+        bundleDir: Path? = null,
+        additionalArgs: String? = null,
+        env: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
+    ): OpaTestRunConfiguration {
         val runConfig = OpaConfigurationFactory(OpaTestRunConfigurationType())
             .createTemplateConfiguration(myFixture.project) as OpaTestRunConfiguration
 
         runConfig.bundleDir = bundleDir
         runConfig.additionalArgs = additionalArgs
+        runConfig.env = env
         return runConfig
     }
 
@@ -47,7 +53,7 @@ abstract class OpaTestRunConfigurationBase : RunConfigurationTestBase() {
             waitFor()
         }
         UIUtil.dispatchAllInvocationEvents()
-        Disposer.register(project,executionConsole)
+        Disposer.register(project, executionConsole)
         return testsRootNode
     }
 
@@ -107,7 +113,7 @@ abstract class OpaTestRunConfigurationBase : RunConfigurationTestBase() {
                     Paths.get("${OpaTestCase.testResourcesPath}/${dataPath}/${testName}/${node.name}.regex").toFile()
                 )
 
-           val value =  if (node == root) node.output else node.errorMessage ?: ""
+            val value = if (node == root) node.output else node.errorMessage ?: ""
 
 
             assertThat(value)
@@ -146,7 +152,7 @@ abstract class OpaTestRunConfigurationBase : RunConfigurationTestBase() {
 class ToStringPrinter : Printer {
     private val buffer = StringBuilder()
 
-    val output get()= buffer.toString()
+    val output get() = buffer.toString()
 
     override fun print(text: String, contentType: ConsoleViewContentType) {
         buffer.append(text)

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/OpaTestRunConfigurationTest.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/OpaTestRunConfigurationTest.kt
@@ -5,6 +5,8 @@
 
 package org.openpolicyagent.ideaplugin.ide.runconfig.test
 
+import com.google.common.collect.ImmutableMap
+import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.execution.configurations.RuntimeConfigurationError
 import org.assertj.core.api.Assertions
 import org.jdom.Element
@@ -66,21 +68,25 @@ class OpaTestRunConfigurationTest : OpaTestRunConfigurationBase() {
 
     fun `test read external`() {
         val runConfig = createTestConfig()
+        runConfig.env = validEnvs()
 
         val data = Element("root")
         data.writePath("bundledir", validBundleDir())
-        data.writeString("addtionalargs", validAdditionalArgs())
+        data.writeString("additionalargs", validAdditionalArgs())
+        runConfig.env.writeExternal(data)
 
         runConfig.readExternal(data)
 
         Assertions.assertThat(runConfig.bundleDir).isEqualTo(validBundleDir())
         Assertions.assertThat(runConfig.additionalArgs).isEqualTo(validAdditionalArgs())
+        Assertions.assertThat(runConfig.env).isEqualTo(validEnvs())
     }
 
     fun `test write external`() {
         val runConfig = createTestConfig()
         runConfig.bundleDir = validBundleDir()
         runConfig.additionalArgs = validAdditionalArgs()
+        runConfig.env = validEnvs()
 
         val elem = Element("root")
         runConfig.writeExternal(elem)
@@ -88,7 +94,8 @@ class OpaTestRunConfigurationTest : OpaTestRunConfigurationBase() {
 
         val expected = Element("root")
         expected.writePath("bundledir", runConfig.bundleDir)
-        expected.writeString("addtionalargs", runConfig.additionalArgs)
+        expected.writeString("additionalargs", runConfig.additionalArgs)
+        runConfig.env.writeExternal(expected)
 
         Assertions.assertThat(elem.toXmlString()).isEqualTo(expected.toXmlString())
 
@@ -136,6 +143,7 @@ class OpaTestRunConfigurationTest : OpaTestRunConfigurationBase() {
 
     private fun validBundleDir(): Path = Paths.get("${myFixture.tempDirPath}/${bundleDirName}")
     private fun validAdditionalArgs() = "-f pretty -v -t 12s"
+    private fun validEnvs() = EnvironmentVariablesData.DEFAULT.with(ImmutableMap.of("CUSTOM_ENV", "custom-value"))
 
     private companion object {
         const val bundleDirName = "src"

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/OpaTestRunConfigurationTest.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/OpaTestRunConfigurationTest.kt
@@ -5,7 +5,6 @@
 
 package org.openpolicyagent.ideaplugin.ide.runconfig.test
 
-import com.google.common.collect.ImmutableMap
 import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.execution.configurations.RuntimeConfigurationError
 import org.assertj.core.api.Assertions
@@ -143,7 +142,7 @@ class OpaTestRunConfigurationTest : OpaTestRunConfigurationBase() {
 
     private fun validBundleDir(): Path = Paths.get("${myFixture.tempDirPath}/${bundleDirName}")
     private fun validAdditionalArgs() = "-f pretty -v -t 12s"
-    private fun validEnvs() = EnvironmentVariablesData.DEFAULT.with(ImmutableMap.of("CUSTOM_ENV", "custom-value"))
+    private fun validEnvs() = EnvironmentVariablesData.DEFAULT.with(mapOf("CUSTOM_ENV" to "custom-value"))
 
     private companion object {
         const val bundleDirName = "src"

--- a/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/eval_producer_should_generate_config_to_eval_complex_rule.xml
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/eval_producer_should_generate_config_to_eval_complex_rule.xml
@@ -1,6 +1,7 @@
 <configurations>
   <configuration name="eval data.main.abc.efg.rule_1" class="OpaEvalRunConfiguration">
     <option name="query" value="data.main.abc.efg.rule_1" />
-    <option name="addtionalargs" value="-f pretty " />
+    <option name="additionalargs" value="-f pretty " />
+    <envs />
   </configuration>
 </configurations>

--- a/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/eval_producer_should_generate_config_to_eval_package.xml
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/eval_producer_should_generate_config_to_eval_package.xml
@@ -1,9 +1,11 @@
 <configurations>
   <configuration name="eval data.main" class="OpaEvalRunConfiguration">
     <option name="query" value="data.main" />
-    <option name="addtionalargs" value="-f pretty --metrics" />
+    <option name="additionalargs" value="-f pretty --metrics" />
+    <envs />
   </configuration>
   <configuration name="test package" class="OpaTestRunConfiguration">
-    <option name="addtionalargs" value="-f pretty  -r data.main" />
+    <option name="additionalargs" value="-f pretty  -r data.main" />
+    <envs />
   </configuration>
 </configurations>

--- a/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/eval_should_generate_config_to_eval_eval_simple_rule.xml
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/eval_should_generate_config_to_eval_eval_simple_rule.xml
@@ -1,6 +1,7 @@
 <configurations>
   <configuration name="eval data.main.abc.efg.api_version_mgs_tmpl" class="OpaEvalRunConfiguration">
     <option name="query" value="data.main.abc.efg.api_version_mgs_tmpl" />
-    <option name="addtionalargs" value="-f pretty " />
+    <option name="additionalargs" value="-f pretty " />
+    <envs />
   </configuration>
 </configurations>

--- a/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/test_producer_should_generate_config_for_test_rule.xml
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/test_producer_should_generate_config_for_test_rule.xml
@@ -1,5 +1,6 @@
 <configurations>
   <configuration name="test test_1" class="OpaTestRunConfiguration">
-    <option name="addtionalargs" value="-f pretty  -r data.test.main.abc.efg.test_1" />
+    <option name="additionalargs" value="-f pretty  -r data.test.main.abc.efg.test_1" />
+    <envs />
   </configuration>
 </configurations>

--- a/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/test_producer_should_generate_config_to_test_package.xml
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/test_producer_should_generate_config_to_test_package.xml
@@ -1,9 +1,11 @@
 <configurations>
   <configuration name="eval data.main.abc.efg" class="OpaEvalRunConfiguration">
     <option name="query" value="data.main.abc.efg" />
-    <option name="addtionalargs" value="-f pretty --metrics" />
+    <option name="additionalargs" value="-f pretty --metrics" />
+    <envs />
   </configuration>
   <configuration name="test package" class="OpaTestRunConfiguration">
-    <option name="addtionalargs" value="-f pretty  -r data.main.abc.efg" />
+    <option name="additionalargs" value="-f pretty  -r data.main.abc.efg" />
+    <envs />
   </configuration>
 </configurations>


### PR DESCRIPTION
# Description
- add option to configure env vars in eval/test config
- bump version for release to 0.7

Fixes #105 