### PR TITLE
gradle-211.properties: fix version of psiViewerPluginVersion

### DIFF
--- a/gradle-211.properties
+++ b/gradle-211.properties
@@ -6,7 +6,7 @@
 # if you change the version of ide, also change psiViewerPluginVersion accordingly (cf https://plugins.jetbrains.com/plugin/227-psiviewer/versions)
 ideaVersion=IC-2021.1.1
 pycharmCommunityVersion=PC-2021.1.1
-psiViewerPluginVersion=211.6305.21-EAP-SNAPSHOT
+psiViewerPluginVersion=211-SNAPSHOT
 
 # see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for more information
 sinceBuild=211.6693


### PR DESCRIPTION


# Description
the version of `211.6305.21-EAP-SNAPSHOT` does not exist anymore.
