### PR TITLE
fix hack/generate_release_notes.sh: handle annotated tag

### DIFF
--- a/hack/generate_release_notes.sh
+++ b/hack/generate_release_notes.sh
@@ -82,7 +82,9 @@ if [[ -z "${last_release_tag}" ]]; then
   echo "first commit sha is '${start_sha}'"
 else
   echo "last release found. it's tag '${last_release_tag}'"
-  start_sha=$(git rev-parse "${last_release_tag}")
+  # we use git rev-list to get the tagged commit's sha1 in order to handle annotated tag.
+  # git rev-parse on an annotated tag return the the sha1 of the "tag", not the one of the tagged commit
+  start_sha=$(git rev-list --max-count=1 "${last_release_tag}")
   echo "tag '${last_release_tag}' point on commit '${start_sha}'"
 fi
 


### PR DESCRIPTION

# Description

The GitHub workflow that generate release failed with the following error:
```
last release found. it's tag 'v0.7.0'
tag 'v0.7.0' point on commit 'a0ed8c28479c68e0e726e5d95efd11c51855d518'
level=info msg="Using output format: markdown"
level=info msg="Gathering release notes"
level=fatal msg="gathering release notes: listing release notes: listing commits: retrieve start commit: GET https://api.github.com/repos/open-policy-agent/opa-idea-plugin/git/commits/a0ed8c28479c68e0e726e5d95efd11c51855d518: 404 Not Found []"
Error: Process completed with exit code 1.
```

Contrary to old release tags the last one is an annotated tag. The `hack/generate_release_notes.sh` use the command `git rev-parse` to get the tagged commit's sha1. It works fine for "simple" tags but for annotated tags, it returns the sha1 of the tag and not the one of the tagged commit.

**Example:**
Given the following history where  `v0.7.0` is an annotated tag and `v0.6.0` a simple tag

```
$ git log --oneline
68702ad (HEAD -> master) Highlight raw string and update ColorSettingPage accordingly (#122)
212c317 (tag: v0.7.0) Update changelog (#114)
670fe2c Sign commit and restrict test (#117)
[...]
110996f (tag: v0.6.0) set new version in gradle.properties (#103)
```

the command git rev-parse return the following result
```
$ git rev-parse --short v0.6.0
110996f
-> this is the sha1 of the commit for release v0.6.0

$ git rev-parse --short v0.7.0
a0ed8c2

-> this is not the sha1 of the commit for release v0.7.0. it's the sha1 of the annotated tag
```

To fix this problem instead of using `git rev-parse` command  we use the command `git rev-list --max-count=1` which works for both tag types
```
$ git rev-list --max-count=1 --abbrev-commit v0.6.0
110996f
-> this is the sha1 of the commit for release v0.6.0

$ git rev-list --max-count=1 --abbrev-commit v0.7.0
212c317
-> this is the sha1 of the commit for release v0.7.0
```
 