### PR TITLE
Support 2023.3 IDEA Version and Fix Minor Error False Positives

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Download OPA
       run: |
-        OPA_VERSION=v0.59.0
+        OPA_VERSION=v0.61.0
         mkdir -p /tmp/opa_bin
         curl -L -o /tmp/opa_bin/opa https://github.com/open-policy-agent/opa/releases/download/$OPA_VERSION/opa_linux_amd64
         chmod +x /tmp/opa_bin/opa

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,8 +44,8 @@ idea {
 plugins {
     idea
     kotlin("jvm") version "1.9.21"
-    id("org.jetbrains.intellij") version "1.16.1"
-    id("org.jetbrains.grammarkit") version "2022.3.1"
+    id("org.jetbrains.intellij") version "1.17.0"
+    id("org.jetbrains.grammarkit") version "2022.3.2"
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,13 +9,13 @@ kotlin.code.style=official
 baseIDE=idea
 
 # if you change the version of ide, also change psiViewerPluginVersion accordingly (cf https://plugins.jetbrains.com/plugin/227-psiviewer/versions)
-ideaVersion=IC-2023.2
-pycharmCommunityVersion=PC-2023.2
-psiViewerPluginVersion=232.2
+ideaVersion=IC-2023.3
+pycharmCommunityVersion=PC-2023.3
+psiViewerPluginVersion=233.2
 
 # see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for more information
-sinceBuild=232
-untilBuild=233.*
+sinceBuild=233
+untilBuild=241.*
 
 # these two variables will be overwritten by the release process (i.e. the GitHub action) thanks to the env variables:
 #   - ORG_GRADLE_PROJECT_publishToken

--- a/src/main/grammar/Rego.bnf
+++ b/src/main/grammar/Rego.bnf
@@ -67,10 +67,10 @@ module              ::= package (import|  rule)*
 package             ::= "package" ref
 import              ::= "import" ref ( "as" var )?
 rule                ::= "default"?  rule-head  rule-body*
-rule-head           ::= var ( "(" rule-args? ")" )? ("[" term "]" )? ( ( ":=" | "=" ) expr )?
+rule-head           ::= var ( "(" rule-args? ")" )? ("[" term "]" )* ( ( ":=" | "=" ) expr )?
 rule-args           ::= term ( "," term )*
 rule-body           ::= else-expr  | query-block
-else-expr           ::= else "=" expr  query-block? | else "="? query-block
+else-expr           ::= else (':=' | '=') expr  query-block? | else (':=' | '=')? query-block
 query-block         ::= "{" query "}"
 query               ::= ( literal |';' )+
 literal             ::= ( some-decl | literal-expr | "not" literal-expr )  with-modifier*

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/RegoHighlighter.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/RegoHighlighter.kt
@@ -26,7 +26,7 @@ class RegoHighlighter : SyntaxHighlighterBase() {
 
     override fun getTokenHighlights(tokenType: IElementType): Array<TextAttributesKey> = pack(tokenToColorMap[tokenType])
 
-    val tokenToColorMap: Map<IElementType, TextAttributesKey> = HashMap()
+    val tokenToColorMap: MutableMap<IElementType, TextAttributesKey> = HashMap()
 
     init {
         fillMap(tokenToColorMap, LINE_COMMENT.textAttributesKey, RegoTypes.COMMENT)

--- a/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/else_keyword.rego
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/else_keyword.rego
@@ -56,6 +56,12 @@ check_only_equal_querry_for_else = true {
     true
 }
 
+check_else_with_colon_assignment_op {
+    input.x < input.y
+} else := true {
+    input.y < input.x
+} else := false
+
 # issue 84
 check_empty_query_else = true {
     input.x < input.y

--- a/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/rule_head.rego
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/rule_head.rego
@@ -16,3 +16,6 @@ c := a1 & a2 | a3 - b
 
 d := 1+2 - array.concat(array1, array2)[2]
 e := array.concat(array1, array2)[0] + array.concat(array1, array2)[1]
+
+# multidimensional array
+f["first"]["second"] := "some value"


### PR DESCRIPTION
# Description
* Compatibility: upgrade to 2023.3 / 233.2 version
* Grammar: rules with multidimensional array heads support
* Grammar: else expressions no longer consider ':=' invalid
* tests: bump OPA version to v0.61.0

 
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`

If you just want to link an issue but not automatically close it, use `Ref #<issue number>` instead of  `Fixes`
-->
Fixes #165
Fixes #151 
