### PR TITLE
Make compatible with newer Jetbrains versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ psiViewerPluginVersion=233.2
 
 # see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for more information
 sinceBuild=233
-untilBuild=241.*
+untilBuild=242.*
 
 # these two variables will be overwritten by the release process (i.e. the GitHub action) thanks to the env variables:
 #   - ORG_GRADLE_PROJECT_publishToken


### PR DESCRIPTION
Make this plugin compatible with newer JetBrains versions. Tested locally on GoLand 2024.2.

# Description
Simple compatibility marker update.
 